### PR TITLE
Added stake.sonicsnipebot.com to the Allow List.

### DIFF
--- a/allowlists/domain-list.json
+++ b/allowlists/domain-list.json
@@ -351,6 +351,7 @@
     "spritz.finance",
     "stake.blob.store",
     "stake.walrus.site",
+    "stake.sonicsnipebot.com"
     "stingraylabs.xyz",
     "storknft.com",
     "strater.xyz",


### PR DESCRIPTION
### Title: Add Sonic Snipe Bot staking platform to the allowlist

### Description:
We have added our staking platform, **Sonic Snipe Bot** (https://sonicsnipebot.com), to the allowlist. Our platform has been audited to ensure security and reliability. You can find the audit report here: [Sonic Snipe Bot Staking Contract Audit Report](https://github.com/Vital-block/Smart-Contract-Audit/blob/main/SONICSNIPEBOT%20STAKING%20CONTRACT%20AUDIT%20REPORT.pdf).

We kindly request a review and approval of this addition. Thank you for your time and consideration.
