### PR TITLE
added vendettagame.xyz to allow domains list

### DIFF
--- a/allowlists/domain-list.json
+++ b/allowlists/domain-list.json
@@ -470,6 +470,7 @@
     "xociety.io",
     "yousui.io",
     "zebec.io",
-    "zip2box.com"
+    "zip2box.com",
+    "vendettagame.xyz"
   ]
 }


### PR DESCRIPTION
Hello Team,

I am submitting this pull request to whitelist the domain vendettagame.xyz in the allowed domains list. We are currently developing The Vendetta Game, a fully on-chain multiplayer role-playing and strategy game built on the SUI Network. As we approach the launch of our game, whitelisting this domain will ensure a smoother and safer experience for users interacting with SUI wallets.

We appreciate your support and consideration.

For more information, feel free to check out our official Twitter handle:
https://x.com/TheVendettaGame 