### PR TITLE
Add daic.capital to whitelist

### DIFF
--- a/allowlists/domain-list.json
+++ b/allowlists/domain-list.json
@@ -133,6 +133,7 @@
     "ct.app",
     "cubicgames.xyz",
     "d4q1chv3fm4t.cloudfront.net",
+    "daic.capital",
     "daossui.io",
     "dbsdxnb5qr2ni.cloudfront.net",
     "deepbook-mainent-pre.netlify.app",


### PR DESCRIPTION
We have a stake feature on https://daic.capital/staking/sui and would like to whitelist daic.capital.