### PR TITLE
Add bubbo.fun to domain list

### DIFF
--- a/allowlists/domain-list.json
+++ b/allowlists/domain-list.json
@@ -551,6 +551,7 @@
     "zebec.io",
     "zip2box.com",
     "zksend-wallet-demo.vercel.app",
-    "zksend.com"
+    "zksend.com",
+    "bubbo.fun"
   ]
 }


### PR DESCRIPTION
Add bubbo.fun to domain list
BUBO is a Crypto Bubbles Map on the SUI Network, allowing you to track real-time token prices and market trends with an interactive and intuitive experience.