### PR TITLE
Adding bulltrend.meme to allow domain list.

### DIFF
--- a/allowlists/domain-list.json
+++ b/allowlists/domain-list.json
@@ -87,6 +87,7 @@
     "buckyou.io",
     "bugpub.org",
     "buildersofstuff.com",
+    "bulltrend.meme",
     "bulksender.app",
     "bw-app-xcs-qa.vercel.app",
     "callboynft.xyz",


### PR DESCRIPTION
You can find approved project by sui-scan here:  `https://suiscan.xyz/mainnet/directory/BullTrendMeme`
