### PR TITLE
Add deeptrade.io to allowed domains

### DIFF
--- a/blocklists/domain-list.json
+++ b/blocklists/domain-list.json
@@ -15253,7 +15253,6 @@
     "deeptoken2.fit",
     "deeptoken2.fyi",
     "deeptoken2.icu",
-    "deeptrade.io",
     "deepv2.com",
     "deepworm.xyz",
     "defellama.top",

--- a/scripts/resources/domains/defis.txt
+++ b/scripts/resources/domains/defis.txt
@@ -39,3 +39,4 @@ poseidollar.com
 1inch.dev
 tradeport.xyz
 buckyou.io
+deeptrade.io


### PR DESCRIPTION
## Description
Add deeptrade.io to the list of allowed DeFi domains and remove it from the blocklist.

## Changes
- Removed deeptrade.io from blocklists/domain-list.json
- Added deeptrade.io to scripts/resources/domains/defis.txt

## Related Issue
Closes #42

## Additional Context
Deeptrade is live on mainnet and currently being flagged as suspicious by the Sui Wallet. 
This PR will allow users to connect their wallets to the platform seamlessly.