### PR TITLE
Add thewatchtower.xyz to domain allowlist

### DIFF
--- a/allowlists/domain-list.json
+++ b/allowlists/domain-list.json
@@ -1,6 +1,7 @@
 {
   "allowlist": [
     "wal.app",
-    "wal.site"
+    "wal.site",
+    "thewatchtower.xyz"
   ]
 }


### PR DESCRIPTION
## Summary

Add `thewatchtower.xyz` to the verified domain allowlist.

**WatchTower** is a chain archaeology and AI intelligence platform for EVE Frontier, built for the EVE Frontier × Sui Hackathon 2026. It reads on-chain Sui events to generate entity dossiers, behavioral fingerprints, and reputation scores.

- **Live**: https://thewatchtower.xyz
- **Repo**: https://github.com/AreteDriver/watchtower
- **Hackathon submission**: https://www.deepsurge.xyz/projects/72145312-4889-4150-ae53-2c00748a0476
- **On-chain contracts**: Package `0x3ca7e3af5bf5b072157d02534f5e4013cf11a12b79385c270d97de480e7b7dca` (Sui testnet)

Users see "Unable to verify site security" when approving transactions in Slush wallet because the domain is not in the allowlist.